### PR TITLE
Fix buildsystem to properly honor $(libdir) and other user variables

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,3 +4,5 @@ lib_LTLIBRARIES = libfts.la
 libfts_la_SOURCES = fts.c
 libfts_la_HEADERS = fts.h
 libfts_ladir = $(includedir)
+
+pkgconfig_DATA = musl-fts.pc

--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,9 @@ AC_PREREQ(2.69)
 AC_INIT([fts], [1.2.5], [pullmoll@t-online.de])
 AM_INIT_AUTOMAKE([1.15])
 AC_CONFIG_MACRO_DIRS([m4])
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CC
-AC_PROG_LIBTOOL
 LT_INIT
 
 AC_CHECK_HEADERS(assert.h dirent.h errno.h fcntl.h stdlib.h string.h unistd.h sys/param.h sys/stat.h)
@@ -26,6 +25,8 @@ AC_CHECK_MEMBERS([DIR.dd_fd, DIR.d_fd],,,
 [#include <sys/types.h>
 #include <dirent.h>
 	])
+
+PKG_INSTALLDIR
 
 AC_CONFIG_FILES([Makefile musl-fts.pc])
 AC_OUTPUT

--- a/musl-fts.pc.in
+++ b/musl-fts.pc.in
@@ -1,7 +1,7 @@
-prefix=/usr
-exec_prefix=${prefix}
-libdir=${prefix}/lib
-includedir=${prefix}/include
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
 
 Name: musl-fts
 Description: Implementation of fts(3) functions for musl libc


### PR DESCRIPTION
AX_CREATE_PKGCONFIG_INFO is the recommended way to create .pc files
See: http://www.dwheeler.com/autotools/